### PR TITLE
Make libvirt module work under Fedora

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,9 +26,11 @@ regarding warranty.
 
 So this module was predominantly tested on:
 
-* Puppet 2.7.0rc4
-* Debian Wheezy
-* libvirt 0.9.0
+* Debian Wheezy/libvirt 0.9.0/Puppet 2.7.0rc4
+
+This model is known to work on:
+
+* Fedora 16/libvirt 0.9.6/Puppet 2.7.6
 
 Other combinations may work, and we are happy to obviously take patches to 
 support other stacks.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,6 +87,14 @@ class libvirt (
     hasrestart => true,
   }
 
+  #####################
+  # Users and groups. #
+  #####################
+
+  user { $user:
+    ensure  => present,
+  }
+
   ########################
   # libvirtd.conf Config #
   ########################

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,7 @@ class libvirt (
   # Users and groups. #
   #####################
 
-  user { $user:
+  group { $group:
     ensure => present,
     system => true,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,8 @@ class libvirt (
   #####################
 
   user { $user:
-    ensure  => present,
+    ensure => present,
+    system => true,
   }
 
   ########################

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,8 +92,9 @@ class libvirt (
   #####################
 
   group { $group:
-    ensure => present,
-    system => true,
+    ensure  => present,
+    system  => true,
+    require => Package[$package],
   }
 
   ########################
@@ -163,3 +164,4 @@ class libvirt (
   create_resources("libvirt::qemu_config", $qemu_config)
 
 }
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,8 @@ class libvirt (
     group => root,
     mode => "0644",
     require => Package[$package],
+    ensure => file,
+    notify => Exec['create_libvirtd_conf'],
   }
   create_resources("libvirt::libvirtd_config", $libvirtd_config)
 
@@ -155,6 +157,8 @@ class libvirt (
     group => root,
     mode => "0644",
     require => Package[$package],
+    ensure => file,
+    notify => Exec['create_qemu_conf'],
   }
   create_resources("libvirt::qemu_config", $qemu_config)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,6 +47,16 @@ class libvirt::params {
       $libvirtd_config_file = "${libvirt_config_dir}/libvirtd.conf"
       $qemu_config_file = "${libvirt_config_dir}/qemu.conf"
     }
+    'Fedora': {
+      $libvirt_package = "libvirt"
+      $libvirt_version = "installed"
+      $libvirt_service = "libvirtd"
+      $libvirt_user = "libvirt"
+      $libvirt_group = "libvirt"
+      $libvirt_config_dir = "/etc/libvirt"
+      $libvirtd_config_file = "${libvirt_config_dir}/libvirtd.conf"
+      $qemu_config_file = "${libvirt_config_dir}/qemu.conf"
+    }
     default: {
       fail("Operating system ${operatingsystem} is not supported")
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,7 +47,7 @@ class libvirt::params {
       $libvirtd_config_file = "${libvirt_config_dir}/libvirtd.conf"
       $qemu_config_file = "${libvirt_config_dir}/qemu.conf"
     }
-    'Fedora': {
+    'Fedora', 'CentOS': {
       $libvirt_package = "libvirt"
       $libvirt_version = "installed"
       $libvirt_service = "libvirtd"


### PR DESCRIPTION
This adds basic support for Fedora to the 'libvirt' module. It's mostly just a block in params.pp, but it also adds a user {} resource to create the 'libvirt' user.
