### PR TITLE
Defaults

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,11 +128,6 @@ class libvirt (
   }
   create_resources('libvirt::libvirtd_config', $libvirtd_config)
 
-  # Some minor defaults. These may need to differ per OS in the future.
-  libvirt::libvirtd_config { ['auth_unix_ro', 'auth_unix_rw']: value => 'none' }
-  libvirt::libvirtd_config { 'unix_sock_group': value => $group }
-  libvirt::libvirtd_config { 'unix_sock_rw_perms': value => '0770' }
-
   ####################
   # qemu.conf Config #
   ####################

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,11 +66,11 @@ class libvirt (
   $service = $libvirt::params::libvirt_service,
   $user = $libvirt::params::libvirt_user,
   $group = $libvirt::params::libvirt_group,
-  $libvirtd_config = undef,
+  $libvirtd_config = {},
   $config_dir = $libvirt::params::libvirt_config_dir,
   $libvirtd_config_file = $libvirt::params::libvirtd_config_file,
   $qemu_config_file = $libvirt::params::qemu_config_file,
-  $qemu_config = undef
+  $qemu_config = {}
 
   ) inherits libvirt::params {
 


### PR DESCRIPTION
While adopting the module for SLES I discovered that I had a different expectation on defaults than you:
- On SLES/OpenSuSE the libvirtd.conf and quemu.conf are empty (all comments). The defaults are whatever libvirtd has built in. I ran into this because I wanted to configure unix_sock_group and got a "Duplicate declaration"
- I did not define a hash for qemu.conf thus the undef in the parameter decleration resulted in create_resources complaining.

Tested/Used on SLES 12 with puppet 3.7.1

Cheers
Wonko
